### PR TITLE
office365: Bugfix - Federated auth broken on Splunk SOAR 5.3.1

### DIFF
--- a/ewsonprem_connector.py
+++ b/ewsonprem_connector.py
@@ -231,7 +231,7 @@ class EWSOnPremConnector(BaseConnector):
         saml_assertion = xml_response[start_pos:end_pos]
 
         # base64 encode the assertion
-        saml_assertion_encoded = base64.encodestring(saml_assertion.encode('utf8'))
+        saml_assertion_encoded = base64.encodebytes(saml_assertion.encode('utf8'))
 
         # Now work on sending th assertion, to get the token
         url = '{0}/oauth2/token'.format(config[EWS_JSON_AUTH_URL])

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+Fix python 3.9 compatibility for federated auth


### PR DESCRIPTION
This fixes a crash for federated auth users on Splunk SOAR 5.3.1. See https://docs.python.org/3.9/whatsnew/3.9.html#removed for why this change was required.