### PR TITLE
Update python_version for 3.13

### DIFF
--- a/office365.json
+++ b/office365.json
@@ -16,7 +16,7 @@
     "product_name": "Office 365",
     "product_version_regex": ".*",
     "min_phantom_version": "6.2.2",
-    "python_version": "3",
+    "python_version": ["3.9", "3.13"],
     "fips_compliant": true,
     "latest_tested_versions": [
         "Cloud April 27, 2023"

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -2,3 +2,4 @@
 
 * chore(ci): Pre-commit config updates
 * update dependencies in requirements [PSAAS-22812]
+* Update Python version for 3.13


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13

[_Created by Sourcegraph batch change `grokas-splunk/002-update-python-versions`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/002-update-python-versions)